### PR TITLE
fix: remove redundant Option wrapper from proof_system CLI argument

### DIFF
--- a/dcap-sp1-cli/src/main.rs
+++ b/dcap-sp1-cli/src/main.rs
@@ -63,7 +63,7 @@ struct DcapArgs {
         value_enum,
         default_value = "groth16"
     )]
-    proof_system: Option<ProofSystem>,
+    proof_system: ProofSystem,
 
     /// Optional: Locally verify the proof after it is generated
     #[arg(short = 'v', long = "verify")]
@@ -192,14 +192,10 @@ async fn main() -> Result<()> {
             // Generate the proof
             let (pk, vk) = client.setup(DCAP_ELF);
             println!("ProofSystem: {:?}", args.proof_system);
-            let proof = if let Some(proof_system) = args.proof_system {
-                if proof_system == ProofSystem::Groth16 {
-                    client.prove(&pk, &stdin).groth16().run().unwrap()
-                } else {
-                    client.prove(&pk, &stdin).plonk().run().unwrap()
-                }
-            } else {
+            let proof = if args.proof_system == ProofSystem::Groth16 {
                 client.prove(&pk, &stdin).groth16().run().unwrap()
+            } else {
+                client.prove(&pk, &stdin).plonk().run().unwrap()
             };
 
             let ret_slice = ret.as_slice();


### PR DESCRIPTION

## Summary
Removed unnecessary `Option<ProofSystem>` wrapper from the `--prove-system` CLI argument since it has a default value and was causing dead code.

## Changes
- Changed `proof_system: Option<ProofSystem>` to `proof_system: ProofSystem` in `DcapArgs`
- Simplified proof system selection logic by removing unreachable `else` branch
- Maintained existing functionality while improving code clarity

